### PR TITLE
Windows support, checkpoints, mix-to-vocals

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -21,6 +21,7 @@ def main(args):
 
     print("Loading model from checkpoint " + str(args.load_model))
     state = utils.load_model(model, None, args.load_model)
+    print('Step', state['step'])
 
     preds = predict_song(args, args.input, model)
 

--- a/predict.py
+++ b/predict.py
@@ -6,14 +6,11 @@ from test import predict_song
 from waveunet import Waveunet
 
 def main(args):
-    INSTRUMENTS = ["bass", "drums", "other", "vocals"]
-    NUM_INSTRUMENTS = len(INSTRUMENTS)
-
     # MODEL
     num_features = [args.features*i for i in range(1, args.levels+1)] if args.feature_growth == "add" else \
                    [args.features*2**i for i in range(0, args.levels)]
     target_outputs = int(args.output_size * args.sr)
-    model = Waveunet(args.channels, num_features, args.channels, INSTRUMENTS, kernel_size=args.kernel_size,
+    model = Waveunet(args.channels, num_features, args.channels, args.instruments, kernel_size=args.kernel_size,
                      target_output_size=target_outputs, depth=args.depth, strides=args.strides,
                      conv_type=args.conv_type, res=args.res, separate=args.separate)
 
@@ -33,16 +30,18 @@ def main(args):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
+    parser.add_argument('--instruments', type=str, nargs='+', default=["bass", "drums", "other", "vocals"],
+                        help="List of instruments to separate (default: \"bass drums other vocals\")")
     parser.add_argument('--cuda', action='store_true',
-                        help='use CUDA (default: False)')
+                        help='Use CUDA (default: False)')
     parser.add_argument('--features', type=int, default=32,
-                        help='# of feature channels per layer')
+                        help='Number of feature channels per layer')
     parser.add_argument('--load_model', type=str, default='checkpoints/waveunet/model',
                         help='Reload a previously trained model')
     parser.add_argument('--batch_size', type=int, default=4,
                         help="Batch size")
     parser.add_argument('--levels', type=int, default=6,
-                        help="Number DS/US blocks")
+                        help="Number of DS/US blocks")
     parser.add_argument('--depth', type=int, default=1,
                         help="Number of convs per block")
     parser.add_argument('--sr', type=int, default=44100,

--- a/predict.py
+++ b/predict.py
@@ -5,65 +5,69 @@ import utils
 from test import predict_song
 from waveunet import Waveunet
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--cuda', action='store_true',
-                    help='use CUDA (default: False)')
-parser.add_argument('--features', type=int, default=32,
-                    help='# of feature channels per layer')
-parser.add_argument('--load_model', type=str,
-                    help='Reload a previously trained model')
-parser.add_argument('--batch_size', type=int, default=4,
-                    help="Batch size")
-parser.add_argument('--levels', type=int, default=6,
-                    help="Number DS/US blocks")
-parser.add_argument('--depth', type=int, default=1,
-                    help="Number of convs per block")
-parser.add_argument('--sr', type=int, default=44100,
-                    help="Sampling rate")
-parser.add_argument('--channels', type=int, default=2,
-                    help="Number of input audio channels")
-parser.add_argument('--kernel_size', type=int, default=5,
-                    help="Filter width of kernels. Has to be an odd number")
-parser.add_argument('--output_size', type=float, default=2.0,
-                    help="Output duration")
-parser.add_argument('--strides', type=int, default=4,
-                    help="Strides in Waveunet")
-parser.add_argument('--conv_type', type=str, default="gn",
-                    help="Type of convolution (normal, BN-normalised, GN-normalised): normal/bn/gn")
-parser.add_argument('--res', type=str, default="fixed",
-                    help="Resampling strategy: fixed sinc-based lowpass filtering or learned conv layer: fixed/learned")
-parser.add_argument('--separate', type=int, default=1,
-                    help="Train separate model for each source (1) or only one (0)")
-parser.add_argument('--feature_growth', type=str, default="double",
-                    help="How the features in each layer should grow, either (add) the initial number of features each time, or multiply by 2 (double)")
+def main(args):
+    INSTRUMENTS = ["bass", "drums", "other", "vocals"]
+    NUM_INSTRUMENTS = len(INSTRUMENTS)
 
-parser.add_argument('--input', type=str, default=os.path.join("audio_examples", "Cristina Vane - So Easy", "mix.mp3"),
-                    help="Path to input mixture to be separated")
-parser.add_argument('--output', type=str, default=None, help="Output path (same folder as input path if not set)")
+    # MODEL
+    num_features = [args.features*i for i in range(1, args.levels+1)] if args.feature_growth == "add" else \
+                   [args.features*2**i for i in range(0, args.levels)]
+    target_outputs = int(args.output_size * args.sr)
+    model = Waveunet(args.channels, num_features, args.channels, INSTRUMENTS, kernel_size=args.kernel_size,
+                     target_output_size=target_outputs, depth=args.depth, strides=args.strides,
+                     conv_type=args.conv_type, res=args.res, separate=args.separate)
 
-args = parser.parse_args()
+    if args.cuda:
+        model = utils.DataParallel(model)
+        print("move model to gpu")
+        model.cuda()
 
-INSTRUMENTS = ["bass", "drums", "other", "vocals"]
-NUM_INSTRUMENTS = len(INSTRUMENTS)
+    print("Loading model from checkpoint " + str(args.load_model))
+    state = utils.load_model(model, None, args.load_model)
 
-# MODEL
-num_features = [args.features*i for i in range(1, args.levels+1)] if args.feature_growth == "add" else \
-               [args.features*2**i for i in range(0, args.levels)]
-target_outputs = int(args.output_size * args.sr)
-model = Waveunet(args.channels, num_features, args.channels, INSTRUMENTS, kernel_size=args.kernel_size,
-                 target_output_size=target_outputs, depth=args.depth, strides=args.strides,
-                 conv_type=args.conv_type, res=args.res, separate=args.separate)
+    preds = predict_song(args, args.input, model)
 
-if args.cuda:
-    model = utils.DataParallel(model)
-    print("move model to gpu")
-    model.cuda()
+    output_folder = os.path.dirname(args.input) if args.output is None else args.output
+    for inst in preds.keys():
+        utils.write_wav(os.path.join(output_folder, os.path.basename(args.input) + "_" + inst + ".wav"), preds[inst], args.sr)
 
-print("Loading model from checkpoint " + str(args.load_model))
-state = utils.load_model(model, None, args.load_model)
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cuda', action='store_true',
+                        help='use CUDA (default: False)')
+    parser.add_argument('--features', type=int, default=32,
+                        help='# of feature channels per layer')
+    parser.add_argument('--load_model', type=str, default='checkpoints/waveunet/model',
+                        help='Reload a previously trained model')
+    parser.add_argument('--batch_size', type=int, default=4,
+                        help="Batch size")
+    parser.add_argument('--levels', type=int, default=6,
+                        help="Number DS/US blocks")
+    parser.add_argument('--depth', type=int, default=1,
+                        help="Number of convs per block")
+    parser.add_argument('--sr', type=int, default=44100,
+                        help="Sampling rate")
+    parser.add_argument('--channels', type=int, default=2,
+                        help="Number of input audio channels")
+    parser.add_argument('--kernel_size', type=int, default=5,
+                        help="Filter width of kernels. Has to be an odd number")
+    parser.add_argument('--output_size', type=float, default=2.0,
+                        help="Output duration")
+    parser.add_argument('--strides', type=int, default=4,
+                        help="Strides in Waveunet")
+    parser.add_argument('--conv_type', type=str, default="gn",
+                        help="Type of convolution (normal, BN-normalised, GN-normalised): normal/bn/gn")
+    parser.add_argument('--res', type=str, default="fixed",
+                        help="Resampling strategy: fixed sinc-based lowpass filtering or learned conv layer: fixed/learned")
+    parser.add_argument('--separate', type=int, default=1,
+                        help="Train separate model for each source (1) or only one (0)")
+    parser.add_argument('--feature_growth', type=str, default="double",
+                        help="How the features in each layer should grow, either (add) the initial number of features each time, or multiply by 2 (double)")
 
-preds = predict_song(args, args.input, model)
+    parser.add_argument('--input', type=str, default=os.path.join("audio_examples", "Cristina Vane - So Easy", "mix.mp3"),
+                        help="Path to input mixture to be separated")
+    parser.add_argument('--output', type=str, default=None, help="Output path (same folder as input path if not set)")
 
-output_folder = os.path.dirname(args.input) if args.output is None else args.output
-for inst in preds.keys():
-    utils.write_wav(os.path.join(output_folder, os.path.basename(args.input) + "_" + inst + ".wav"), preds[inst], args.sr)
+    args = parser.parse_args()
+
+    main(args)

--- a/test.py
+++ b/test.py
@@ -150,7 +150,7 @@ def validate(args, model, criterion, test_data):
 
             total_loss += (1. / float(example_num + 1)) * (avg_loss - total_loss)
 
-            pbar.set_description("Current loss: " + str(total_loss))
+            pbar.set_description("Current loss: {:.4f}".format(total_loss))
             pbar.update(1)
 
     return total_loss

--- a/train.py
+++ b/train.py
@@ -1,11 +1,13 @@
 import argparse
 import os
 import time
+from functools import partial
 
 import torch
 import pickle
 import numpy as np
 
+import torch.nn as nn
 from torch.utils.tensorboard import SummaryWriter
 from torch.optim import Adam
 from tqdm import tqdm
@@ -15,210 +17,214 @@ from data import get_musdb_folds, SeparationDataset, random_amplify, crop
 from test import evaluate, validate
 from waveunet import Waveunet
 
-## TRAIN PARAMETERS
-parser = argparse.ArgumentParser()
-parser.add_argument('--cuda', action='store_true',
-                    help='use CUDA (default: False)')
-parser.add_argument('--num_workers', type=int, default=1,
-                    help='Number of data loader worker threads (default: 1)')
-parser.add_argument('--features', type=int, default=32,
-                    help='# of feature channels per layer')
-parser.add_argument('--log_dir', type=str, default='logs/waveunet',
-                    help='Folder to write logs into')
-parser.add_argument('--dataset_dir', type=str, default="/mnt/windaten/Datasets/MUSDB18HQ",
-                    help='Dataset path')
-parser.add_argument('--hdf_dir', type=str, default="hdf",
-                    help='Dataset path')
-parser.add_argument('--checkpoint_dir', type=str, default='checkpoints/waveunet',
-                    help='Folder to write checkpoints into')
-parser.add_argument('--load_model', type=str, default=None,
-                    help='Reload a previously trained model (whole task model)')
-parser.add_argument('--lr', type=float, default=1e-3,
-                    help='initial learning rate (default: 5e-4)')
-parser.add_argument('--min_lr', type=float, default=5e-5,
-                    help='initial learning rate (default: 5e-4)')
-parser.add_argument('--cycles', type=int, default=2,
-                    help='Number of LR cycles per epoch')
-parser.add_argument('--batch_size', type=int, default=4,
-                    help="Batch size")
-parser.add_argument('--levels', type=int, default=6,
-                    help="Number DS/US blocks")
-parser.add_argument('--depth', type=int, default=1,
-                    help="Number of convs per block")
-parser.add_argument('--sr', type=int, default=44100,
-                    help="Sampling rate")
-parser.add_argument('--channels', type=int, default=2,
-                    help="Number of input audio channels")
-parser.add_argument('--kernel_size', type=int, default=5,
-                    help="Filter width of kernels. Has to be an odd number")
-parser.add_argument('--output_size', type=float, default=2.0,
-                    help="Output duration")
-parser.add_argument('--strides', type=int, default=4,
-                    help="Strides in Waveunet")
-parser.add_argument('--patience', type=int, default=20,
-                    help="Patience for early stopping on validation set")
-parser.add_argument('--example_freq', type=int, default=200,
-                    help="Write an audio summary into Tensorboard logs every X training iterations")
-parser.add_argument('--loss', type=str, default="L1",
-                    help="L1 or L2")
-parser.add_argument('--conv_type', type=str, default="gn",
-                    help="Type of convolution (normal, BN-normalised, GN-normalised): normal/bn/gn")
-parser.add_argument('--res', type=str, default="fixed",
-                    help="Resampling strategy: fixed sinc-based lowpass filtering or learned conv layer: fixed/learned")
-parser.add_argument('--separate', type=int, default=1,
-                    help="Train separate model for each source (1) or only one (0)")
-parser.add_argument('--feature_growth', type=str, default="double",
-                    help="How the features in each layer should grow, either (add) the initial number of features each time, or multiply by 2 (double)")
+def main(args):
+    INSTRUMENTS = ["bass", "drums", "other", "vocals"]
+    NUM_INSTRUMENTS = len(INSTRUMENTS)
 
-args = parser.parse_args()
+    #torch.backends.cudnn.benchmark=True # This makes dilated conv much faster for CuDNN 7.5
 
-INSTRUMENTS = ["bass", "drums", "other", "vocals"]
-NUM_INSTRUMENTS = len(INSTRUMENTS)
+    # MODEL
+    num_features = [args.features*i for i in range(1, args.levels+1)] if args.feature_growth == "add" else \
+                   [args.features*2**i for i in range(0, args.levels)]
+    target_outputs = int(args.output_size * args.sr)
+    model = Waveunet(args.channels, num_features, args.channels, INSTRUMENTS, kernel_size=args.kernel_size,
+                     target_output_size=target_outputs, depth=args.depth, strides=args.strides,
+                     conv_type=args.conv_type, res=args.res, separate=args.separate)
 
-#torch.backends.cudnn.benchmark=True # This makes dilated conv much faster for CuDNN 7.5
+    if args.cuda:
+        model = utils.DataParallel(model)
+        print("move model to gpu")
+        model.cuda()
 
-# MODEL
-num_features = [args.features*i for i in range(1, args.levels+1)] if args.feature_growth == "add" else \
-               [args.features*2**i for i in range(0, args.levels)]
-target_outputs = int(args.output_size * args.sr)
-model = Waveunet(args.channels, num_features, args.channels, INSTRUMENTS, kernel_size=args.kernel_size,
-                 target_output_size=target_outputs, depth=args.depth, strides=args.strides,
-                 conv_type=args.conv_type, res=args.res, separate=args.separate)
+    print('model: ', model)
+    print('parameter count: ', str(sum(p.numel() for p in model.parameters())))
 
-if args.cuda:
-    model = utils.DataParallel(model)
-    print("move model to gpu")
-    model.cuda()
+    writer = SummaryWriter(args.log_dir)
 
-print('model: ', model)
-print('parameter count: ', str(sum(p.numel() for p in model.parameters())))
+    ### DATASET
+    musdb = get_musdb_folds(args.dataset_dir)
+    # If not data augmentation, at least crop targets to fit model output shape
+    crop_func = partial(crop, shapes=model.shapes)
+    # Data augmentation function for training
+    augment_func = partial(random_amplify, shapes=model.shapes, min=0.7, max=1.0)
+    train_data = SeparationDataset(musdb, "train", INSTRUMENTS, args.sr, args.channels, model.shapes, True, args.hdf_dir, audio_transform=augment_func)
+    val_data = SeparationDataset(musdb, "val", INSTRUMENTS, args.sr, args.channels, model.shapes, False, args.hdf_dir, audio_transform=crop_func)
+    test_data = SeparationDataset(musdb, "test", INSTRUMENTS, args.sr, args.channels, model.shapes, False, args.hdf_dir, audio_transform=crop_func)
 
-writer = SummaryWriter(args.log_dir)
+    dataloader = torch.utils.data.DataLoader(train_data, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers, worker_init_fn=utils.worker_init_fn)
 
-### DATASET
-musdb = get_musdb_folds(args.dataset_dir)
-# If not data augmentation, at least crop targets to fit model output shape
-crop_func = lambda mix,targets : crop(mix, targets, model.shapes)
-# Data augmentation function for training
-augment_func = lambda mix,targets : random_amplify(mix, targets, model.shapes, 0.7, 1.0)
-train_data = SeparationDataset(musdb, "train", INSTRUMENTS, args.sr, args.channels, model.shapes, True, args.hdf_dir, audio_transform=augment_func)
-val_data = SeparationDataset(musdb, "val", INSTRUMENTS, args.sr, args.channels, model.shapes, False, args.hdf_dir, audio_transform=crop_func)
-test_data = SeparationDataset(musdb, "test", INSTRUMENTS, args.sr, args.channels, model.shapes, False, args.hdf_dir, audio_transform=crop_func)
+    ##### TRAINING ####
 
-dataloader = torch.utils.data.DataLoader(train_data, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers, worker_init_fn=utils.worker_init_fn)
-
-##### TRAINING ####
-
-# Set up the loss function
-if args.loss == "L1":
-    criterion = lambda x,y : torch.mean(torch.abs(x - y))
-elif args.loss == "L2":
-    criterion = lambda x,y : torch.mean((x-y)**2)
-else:
-    raise NotImplementedError("Couldn't find this loss!")
-
-# Set up optimiser
-optimizer = Adam(params=model.parameters(), lr=args.lr)
-
-# Set up training state dict that will also be saved into checkpoints
-state = {"step" : 0,
-         "worse_epochs" : 0,
-         "epochs" : 0,
-         "best_loss" : np.Inf}
-
-# LOAD MODEL CHECKPOINT IF DESIRED
-if args.load_model is not None:
-    print("Continuing training full model from checkpoint " + str(args.load_model))
-    state = utils.load_model(model, optimizer, args.load_model)
-
-print('TRAINING START')
-while state["worse_epochs"] < args.patience:
-    print("Training one epoch from iteration " + str(state["step"]))
-    avg_time = 0.
-    model.train()
-    with tqdm(total=len(train_data) // args.batch_size) as pbar:
-        np.random.seed()
-        for example_num, (x, targets) in enumerate(dataloader):
-            if args.cuda:
-                x = x.cuda()
-                for k in list(targets.keys()):
-                    targets[k] = targets[k].cuda()
-
-            t = time.time()
-
-            # Set LR for this iteration
-            utils.set_cyclic_lr(optimizer, example_num, len(train_data) // args.batch_size, args.cycles, args.min_lr, args.lr)
-            writer.add_scalar("lr", utils.get_lr(optimizer), state["step"])
-
-            # Compute loss for each instrument/model
-            optimizer.zero_grad()
-            outputs, avg_loss = utils.compute_loss(model, x, targets, criterion, compute_grad=True)
-
-            optimizer.step()
-
-            state["step"] += 1
-
-            t = time.time() - t
-            avg_time += (1. / float(example_num + 1)) * (t - avg_time)
-
-            writer.add_scalar("train_loss", avg_loss, state["step"])
-
-            if example_num % args.example_freq == 0:
-                input_centre = torch.mean(x[0, :, model.shapes["output_start_frame"]:model.shapes["output_end_frame"]], 0) # Stereo not supported for logs yet
-                writer.add_audio("input", input_centre, state["step"], sample_rate=args.sr)
-
-                for inst in outputs.keys():
-                    writer.add_audio(inst + "_pred", torch.mean(outputs[inst][0], 0), state["step"], sample_rate=args.sr)
-                    writer.add_audio(inst + "_target", torch.mean(targets[inst][0], 0), state["step"], sample_rate=args.sr)
-
-            pbar.update(1)
-
-    # VALIDATE
-    val_loss = validate(args, model, criterion, val_data)
-    print("VALIDATION FINISHED: LOSS: " + str(val_loss))
-    writer.add_scalar("val_loss", val_loss, state["step"])
-
-    # EARLY STOPPING CHECK
-    checkpoint_path = os.path.join(args.checkpoint_dir, "checkpoint_" + str(state["step"]))
-    if val_loss >= state["best_loss"]:
-        state["worse_epochs"] += 1
+    # Set up the loss function
+    if args.loss == "L1":
+        criterion = nn.L1Loss()
+    elif args.loss == "L2":
+        criterion = nn.MSELoss()
     else:
-        print("MODEL IMPROVED ON VALIDATION SET!")
-        state["worse_epochs"] = 0
-        state["best_loss"] = val_loss
-        state["best_checkpoint"] = checkpoint_path
+        raise NotImplementedError("Couldn't find this loss!")
 
-    # CHECKPOINT
-    print("Saving model...")
-    utils.save_model(model, optimizer, state, checkpoint_path)
+    # Set up optimiser
+    optimizer = Adam(params=model.parameters(), lr=args.lr)
 
-    state["epochs"] += 1
+    # Set up training state dict that will also be saved into checkpoints
+    state = {"step" : 0,
+             "worse_epochs" : 0,
+             "epochs" : 0,
+             "best_loss" : np.Inf}
 
-#### TESTING ####
-# Test loss
-print("TESTING")
+    # LOAD MODEL CHECKPOINT IF DESIRED
+    if args.load_model is not None:
+        print("Continuing training full model from checkpoint " + str(args.load_model))
+        state = utils.load_model(model, optimizer, args.load_model)
 
-# Load best model based on validation loss
-state = utils.load_model(model, None, state["best_checkpoint"])
-test_loss = validate(args, model, criterion, test_data)
-print("TEST FINISHED: LOSS: " + str(test_loss))
-writer.add_scalar("test_loss", test_loss, state["step"])
+    print('TRAINING START')
+    while state["worse_epochs"] < args.patience:
+        print("Training one epoch from iteration " + str(state["step"]))
+        avg_time = 0.
+        model.train()
+        with tqdm(total=len(train_data) // args.batch_size) as pbar:
+            np.random.seed()
+            for example_num, (x, targets) in enumerate(dataloader):
+                if args.cuda:
+                    x = x.cuda()
+                    for k in list(targets.keys()):
+                        targets[k] = targets[k].cuda()
 
-# Mir_eval metrics
-test_metrics = evaluate(args, musdb["test"], model, INSTRUMENTS)
+                t = time.time()
 
-# Dump all metrics results into pickle file for later analysis if needed
-with open(os.path.join(args.checkpoint_dir, "results.pkl"), "wb") as f:
-    pickle.dump(test_metrics, f)
+                # Set LR for this iteration
+                utils.set_cyclic_lr(optimizer, example_num, len(train_data) // args.batch_size, args.cycles, args.min_lr, args.lr)
+                writer.add_scalar("lr", utils.get_lr(optimizer), state["step"])
 
-# Write most important metrics into Tensorboard log
-avg_SDRs = {inst : np.mean([np.nanmean(song[inst]["SDR"]) for song in test_metrics]) for inst in INSTRUMENTS}
-avg_SIRs = {inst : np.mean([np.nanmean(song[inst]["SIR"]) for song in test_metrics]) for inst in INSTRUMENTS}
-for inst in INSTRUMENTS:
-    writer.add_scalar("test_SDR_" + inst, avg_SDRs[inst], state["step"])
-    writer.add_scalar("test_SIR_" + inst, avg_SIRs[inst], state["step"])
-overall_SDR = np.mean([v for v in avg_SDRs.values()])
-writer.add_scalar("test_SDR", overall_SDR)
-print("SDR: " + str(overall_SDR))
+                # Compute loss for each instrument/model
+                optimizer.zero_grad()
+                outputs, avg_loss = utils.compute_loss(model, x, targets, criterion, compute_grad=True)
 
-writer.close()
+                optimizer.step()
+
+                state["step"] += 1
+
+                t = time.time() - t
+                avg_time += (1. / float(example_num + 1)) * (t - avg_time)
+
+                writer.add_scalar("train_loss", avg_loss, state["step"])
+
+                if example_num % args.example_freq == 0:
+                    input_centre = torch.mean(x[0, :, model.shapes["output_start_frame"]:model.shapes["output_end_frame"]], 0) # Stereo not supported for logs yet
+                    writer.add_audio("input", input_centre, state["step"], sample_rate=args.sr)
+
+                    for inst in outputs.keys():
+                        writer.add_audio(inst + "_pred", torch.mean(outputs[inst][0], 0), state["step"], sample_rate=args.sr)
+                        writer.add_audio(inst + "_target", torch.mean(targets[inst][0], 0), state["step"], sample_rate=args.sr)
+
+                pbar.update(1)
+
+        # VALIDATE
+        val_loss = validate(args, model, criterion, val_data)
+        print("VALIDATION FINISHED: LOSS: " + str(val_loss))
+        writer.add_scalar("val_loss", val_loss, state["step"])
+
+        # EARLY STOPPING CHECK
+        checkpoint_path = os.path.join(args.checkpoint_dir, "checkpoint_" + str(state["step"]))
+        if val_loss >= state["best_loss"]:
+            state["worse_epochs"] += 1
+        else:
+            print("MODEL IMPROVED ON VALIDATION SET!")
+            state["worse_epochs"] = 0
+            state["best_loss"] = val_loss
+            state["best_checkpoint"] = checkpoint_path
+
+        # CHECKPOINT
+        print("Saving model...")
+        utils.save_model(model, optimizer, state, checkpoint_path)
+
+        state["epochs"] += 1
+
+    #### TESTING ####
+    # Test loss
+    print("TESTING")
+
+    # Load best model based on validation loss
+    state = utils.load_model(model, None, state["best_checkpoint"])
+    test_loss = validate(args, model, criterion, test_data)
+    print("TEST FINISHED: LOSS: " + str(test_loss))
+    writer.add_scalar("test_loss", test_loss, state["step"])
+
+    # Mir_eval metrics
+    test_metrics = evaluate(args, musdb["test"], model, INSTRUMENTS)
+
+    # Dump all metrics results into pickle file for later analysis if needed
+    with open(os.path.join(args.checkpoint_dir, "results.pkl"), "wb") as f:
+        pickle.dump(test_metrics, f)
+
+    # Write most important metrics into Tensorboard log
+    avg_SDRs = {inst : np.mean([np.nanmean(song[inst]["SDR"]) for song in test_metrics]) for inst in INSTRUMENTS}
+    avg_SIRs = {inst : np.mean([np.nanmean(song[inst]["SIR"]) for song in test_metrics]) for inst in INSTRUMENTS}
+    for inst in INSTRUMENTS:
+        writer.add_scalar("test_SDR_" + inst, avg_SDRs[inst], state["step"])
+        writer.add_scalar("test_SIR_" + inst, avg_SIRs[inst], state["step"])
+    overall_SDR = np.mean([v for v in avg_SDRs.values()])
+    writer.add_scalar("test_SDR", overall_SDR)
+    print("SDR: " + str(overall_SDR))
+
+    writer.close()
+
+if __name__ == '__main__':
+    ## TRAIN PARAMETERS
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cuda', action='store_true',
+                        help='use CUDA (default: False)')
+    parser.add_argument('--num_workers', type=int, default=1,
+                        help='Number of data loader worker threads (default: 1)')
+    parser.add_argument('--features', type=int, default=32,
+                        help='# of feature channels per layer')
+    parser.add_argument('--log_dir', type=str, default='logs/waveunet',
+                        help='Folder to write logs into')
+    parser.add_argument('--dataset_dir', type=str, default="/mnt/windaten/Datasets/MUSDB18HQ",
+                        help='Dataset path')
+    parser.add_argument('--hdf_dir', type=str, default="hdf",
+                        help='Dataset path')
+    parser.add_argument('--checkpoint_dir', type=str, default='checkpoints/waveunet',
+                        help='Folder to write checkpoints into')
+    parser.add_argument('--load_model', type=str, default=None,
+                        help='Reload a previously trained model (whole task model)')
+    parser.add_argument('--lr', type=float, default=1e-3,
+                        help='initial learning rate (default: 5e-4)')
+    parser.add_argument('--min_lr', type=float, default=5e-5,
+                        help='initial learning rate (default: 5e-4)')
+    parser.add_argument('--cycles', type=int, default=2,
+                        help='Number of LR cycles per epoch')
+    parser.add_argument('--batch_size', type=int, default=4,
+                        help="Batch size")
+    parser.add_argument('--levels', type=int, default=6,
+                        help="Number DS/US blocks")
+    parser.add_argument('--depth', type=int, default=1,
+                        help="Number of convs per block")
+    parser.add_argument('--sr', type=int, default=44100,
+                        help="Sampling rate")
+    parser.add_argument('--channels', type=int, default=2,
+                        help="Number of input audio channels")
+    parser.add_argument('--kernel_size', type=int, default=5,
+                        help="Filter width of kernels. Has to be an odd number")
+    parser.add_argument('--output_size', type=float, default=2.0,
+                        help="Output duration")
+    parser.add_argument('--strides', type=int, default=4,
+                        help="Strides in Waveunet")
+    parser.add_argument('--patience', type=int, default=20,
+                        help="Patience for early stopping on validation set")
+    parser.add_argument('--example_freq', type=int, default=200,
+                        help="Write an audio summary into Tensorboard logs every X training iterations")
+    parser.add_argument('--loss', type=str, default="L1",
+                        help="L1 or L2")
+    parser.add_argument('--conv_type', type=str, default="gn",
+                        help="Type of convolution (normal, BN-normalised, GN-normalised): normal/bn/gn")
+    parser.add_argument('--res', type=str, default="fixed",
+                        help="Resampling strategy: fixed sinc-based lowpass filtering or learned conv layer: fixed/learned")
+    parser.add_argument('--separate', type=int, default=1,
+                        help="Train separate model for each source (1) or only one (0)")
+    parser.add_argument('--feature_growth', type=str, default="double",
+                        help="How the features in each layer should grow, either (add) the initial number of features each time, or multiply by 2 (double)")
+
+    args = parser.parse_args()
+
+    main(args)

--- a/utils.py
+++ b/utils.py
@@ -26,7 +26,7 @@ def compute_output(model, inputs):
 
 def compute_loss(model, inputs, targets, criterion, compute_grad=False):
     '''
-    Computes gradients of model with given inputs tand targets and loss function.
+    Computes gradients of model with given inputs and targets and loss function.
     Optionally backpropagates to compute gradients for weights.
     Procedure depends on whether we have one model for each source or not
     :param model: Model to train with
@@ -123,18 +123,20 @@ class DataParallel(torch.nn.DataParallel):
         except AttributeError:
             return getattr(self.module, name)
 
-def save_model(model, optimizer, step, path):
+def save_model(model, optimizer, state, path):
     if isinstance(model, torch.nn.DataParallel):
-        model = model.module  # save state dict of wrapper module
+        model = model.module  # save state dict of wrapped module
     if len(os.path.dirname(path)) > 0 and not os.path.exists(os.path.dirname(path)):
         os.makedirs(os.path.dirname(path))
     torch.save({
         'model_state_dict': model.state_dict(),
         'optimizer_state_dict': optimizer.state_dict(),
-        'step': step,
+        'state': state,  # state of training loop (was 'step')
     }, path)
 
 def load_model(model, optimizer, path):
+    if isinstance(model, torch.nn.DataParallel):
+        model = model.module  # load state dict of wrapped module
     checkpoint = torch.load(path)
     try:
         model.load_state_dict(checkpoint['model_state_dict'])
@@ -150,8 +152,12 @@ def load_model(model, optimizer, path):
         model.load_state_dict(model_state_dict_fixed)
     if optimizer is not None:
         optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-    step = checkpoint['step']
-    return step
+    if 'state' in checkpoint:
+        state = checkpoint['state']
+    else:
+        # older checkpoitns only store step, rest of state won't be there
+        state = {'step': checkpoint['step']}
+    return state
 
 def load_latest_model_from(model, optimizer, location):
     files = [location + "/" + f for f in os.listdir(location)]


### PR DESCRIPTION
These are several small changes that may be of general interest.
I realize mixing issues in a single PR is not ideal, but didn't want to separate them in case you weren't interested altogether.

Changes
- Windows support
  - Wrapped code in `if __name__ == '__main__'` (needed for multiprocessing)
  - Removed lambdas (needed for pickling for multiprocessing)
- Fixed some inconsistencies in checkpoint loading/saving
  - When saving, save state dict of module wrapped by `nn.DataParallel`, not the wrapper itself
  - When loading, remove `module.` prefix from state dict keys if `nn.DataParallel` wrapper was saved (the provided pretrained weights for instance)
  - There was some confusion about storing `step` or `state` (training loop state) in the checkpoints. Changed to whole state.
- Allow separating just vocals from input mixture
  - Added `--instruments` command line argument, rather than hard coding the list.
  - Changed `random_amplify` so it doesn't assume instruments sum to mix.