### PR TITLE
Update Replicate to use multiple outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+checkpoints/waveunet/
+.cog

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ We provide the default model in a pre-trained form as download so you can separa
 Download our pretrained model [here](https://www.dropbox.com/s/r374hce896g4xlj/models.7z?dl=1).
 Extract the archive into the ``checkpoints`` subfolder in this repository, so that you have one subfolder for each model (e.g. ``REPO/checkpoints/waveunet``)
 
+If you have Docker installed, you can run this script to download the weights from [Replicate](https://replicate.com/f90/wave-u-net-pytorch):
+
+    $ script/download-weights
+
 ## Run pretrained model
 
 To apply our pretrained model to any of your own songs, simply point to its audio file path using the ``input_path`` parameter:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wave-U-Net (Pytorch)
-<a href="https://replicate.ai/f90/wave-u-net-pytorch"><img src="https://img.shields.io/static/v1?label=Replicate&message=Demo and Docker Image&color=darkgreen" height=20></a>
+<a href="https://replicate.com/f90/wave-u-net-pytorch"><img src="https://replicate.com/f90/wave-u-net-pytorch/badge"></a>
 
 Improved version of the [Wave-U-Net](https://arxiv.org/abs/1806.03185) for audio source separation, implemented in Pytorch.
 

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,5 +1,5 @@
 build:
-  python_version: "3.6"
+  python_version: "3.7"
   gpu: false
   python_packages:
     - future==0.18.2
@@ -17,4 +17,4 @@ build:
   system_packages:
     - libsndfile-dev
     - ffmpeg
-predict: "cog_predict.py:waveunetPredictor"
+predict: "cog_predict.py:Predictor"

--- a/script/download-weights
+++ b/script/download-weights
@@ -1,0 +1,3 @@
+#!/bin/bash
+id=$(docker create r8.im/f90/wave-u-net-pytorch)
+docker cp $id:/src/checkpoints ./


### PR DESCRIPTION
Hi @f90!

This is a follow-up to #9, where we added the Cog configuration and a [Replicate demo](https://replicate.com/f90/wave-u-net-pytorch).

We've now added support for multiple outputs, so we can display each instrument with its own player. Here's a demo of my branch: https://replicate.com/bfirsh/wave-u-net-pytorch

I've also added a little script that downloads the weights from Replicate, because I couldn't figure out the right filenames for them.

If you want to update your Replicate demo, you'll need to run `cog push r8.im/f90/wave-u-net-pytorch` once you've merged your pull request. (I can also do that for you if you'd like, but I wanted to ask permission before changing your demo!)