### PR TITLE
moved epoch state increment to before save

### DIFF
--- a/train.py
+++ b/train.py
@@ -134,11 +134,11 @@ def main(args):
             state["best_loss"] = val_loss
             state["best_checkpoint"] = checkpoint_path
 
+        state["epochs"] += 1
         # CHECKPOINT
         print("Saving model...")
         model_utils.save_model(model, optimizer, state, checkpoint_path)
 
-        state["epochs"] += 1
 
     #### TESTING ####
     # Test loss


### PR DESCRIPTION
saving should be done after incrementing the state["epoch"]
beforehand, if you were to run train for 1 epoch at a time, and then save and reload, it will always be on epoch 0. There is no real issue since the epoch state is actually not being used at all, but were it be used for something, it will create problems.